### PR TITLE
Adding the ability to configure routes group

### DIFF
--- a/src/Config/WriteawayConfig.php
+++ b/src/Config/WriteawayConfig.php
@@ -12,6 +12,7 @@ class WriteawayConfig extends InjectableConfig
 
     protected array $config = [
         'permission' => '',
+        'routeGroup' => 'web',
         'images'     => [
             'storageBucket' => '',
             'thumbnail'     => ['width' => 0, 'height' => 0]
@@ -36,5 +37,10 @@ class WriteawayConfig extends InjectableConfig
     public function thumbnailHeight(): int
     {
         return $this->config['images']['thumbnail']['height'];
+    }
+
+    public function getRouteGroup(): string
+    {
+        return $this->config['routeGroup'];
     }
 }

--- a/tests/Bootloader/WriteawayBootloaderTest.php
+++ b/tests/Bootloader/WriteawayBootloaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Writeaway\Bootloader;
+
+use Spiral\Core\Container;
+use Spiral\Router\GroupRegistry;
+use Spiral\Router\RouteGroup;
+use Spiral\Tests\Writeaway\App\App;
+use Spiral\Tests\Writeaway\TestCase;
+use Spiral\Writeaway\Config\WriteawayConfig;
+
+final class WriteawayBootloaderTest extends TestCase
+{
+    public function testRoutesShouldBeRegisteredInDefaultGroup(): void
+    {
+        /** @var RouteGroup $group */
+        $group = $this->app->get(GroupRegistry::class)->getGroup('web');
+
+        $this->assertTrue($group->hasRoute('writeaway:images:list'));
+        $this->assertTrue($group->hasRoute('writeaway:images:upload'));
+        $this->assertTrue($group->hasRoute('writeaway:images:delete'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:save'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:get'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:bulk'));
+    }
+
+    public function testRoutesShouldBeRegisteredInCustomGroup(): void
+    {
+        $app = App::create([
+            'app' => \dirname(__DIR__) . '/App/',
+            'root' => \dirname(__DIR__) . '/App/',
+            'config' => \dirname(__DIR__) . '/config/',
+        ]);
+        $app->booting(static function (Container $container): void {
+            $container->bind(WriteawayConfig::class, new WriteawayConfig(['routeGroup' => 'foo']));
+        });
+        $app->run();
+
+        /** @var RouteGroup $group */
+        $group = $app->get(GroupRegistry::class)->getGroup('foo');
+
+        $this->assertTrue($group->hasRoute('writeaway:images:list'));
+        $this->assertTrue($group->hasRoute('writeaway:images:upload'));
+        $this->assertTrue($group->hasRoute('writeaway:images:delete'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:save'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:get'));
+        $this->assertTrue($group->hasRoute('writeaway:pieces:bulk'));
+
+        /** @var RouteGroup $group */
+        $group = $app->get(GroupRegistry::class)->getGroup('web');
+
+        $this->assertFalse($group->hasRoute('writeaway:images:list'));
+        $this->assertFalse($group->hasRoute('writeaway:images:upload'));
+        $this->assertFalse($group->hasRoute('writeaway:images:delete'));
+        $this->assertFalse($group->hasRoute('writeaway:pieces:save'));
+        $this->assertFalse($group->hasRoute('writeaway:pieces:get'));
+        $this->assertFalse($group->hasRoute('writeaway:pieces:bulk'));
+    }
+}


### PR DESCRIPTION
Previously, routes were added `without` a group. In SF 3.0, middlewares will `not work` on such routes. Currently, routes will be added to the `web` group (default group in the framework) by default, with the ability to change in the config file.